### PR TITLE
[auth] feat: JWT/리프레시 토큰 처리 및 Swagger 작성

### DIFF
--- a/src/main/java/com/koa/koalamailman/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/koa/koalamailman/domain/auth/controller/AuthController.java
@@ -1,7 +1,15 @@
 package com.koa.koalamailman.domain.auth.controller;
 
 import com.koa.koalamailman.domain.auth.controller.docs.AuthControllerDocs;
+import com.koa.koalamailman.domain.auth.dto.AccessTokenResponse;
+import com.koa.koalamailman.domain.auth.service.RefreshTokenService;
+import com.koa.koalamailman.global.dto.SuccessResponse;
+import com.koa.koalamailman.global.exception.SuccessCode;
+import com.koa.koalamailman.global.security.oauth.CustomUserDetails;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.CookieValue;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -9,4 +17,17 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/auth")
 @RequiredArgsConstructor
 public class AuthController implements AuthControllerDocs {
+
+    private final RefreshTokenService refreshTokenService;
+
+    @PostMapping("/refresh")
+    public SuccessResponse<AccessTokenResponse> refreshAccessToken(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @CookieValue(value = "refresh_token") String refreshToken
+    ) {
+        return SuccessResponse.success(
+                SuccessCode.GET_ACCESS_TOKEN,
+                AccessTokenResponse.from(refreshTokenService.validateAndGenerateAccessToken(userDetails.getUser(), refreshToken))
+        );
+    }
 }

--- a/src/main/java/com/koa/koalamailman/domain/auth/controller/docs/AuthControllerDocs.java
+++ b/src/main/java/com/koa/koalamailman/domain/auth/controller/docs/AuthControllerDocs.java
@@ -1,9 +1,17 @@
 package com.koa.koalamailman.domain.auth.controller.docs;
 
+import com.koa.koalamailman.domain.auth.dto.AccessTokenResponse;
+import com.koa.koalamailman.global.dto.SuccessResponse;
+import com.koa.koalamailman.global.security.oauth.CustomUserDetails;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.CookieValue;
 
+@SecurityRequirement(name = "Authorization")
 @Tag(name = "로그인, 인증", description = "로그인 인증 관련 API입니다.")
 public interface AuthControllerDocs {
     @Operation(
@@ -46,4 +54,21 @@ public interface AuthControllerDocs {
             }
     )
     default void logout() {}
+
+    @Operation(
+            summary = "리프레시 토큰으로 액세스 토큰 재발급",
+            description = """
+            HttpOnly 쿠키의 `refresh_token` 값을 이용해 Access Token을 재발급합니다.
+            - 요청: Cookie에 refresh_token 포함
+            """,
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "재발급 성공"),
+                    @ApiResponse(responseCode = "401", description = "인증 실패(쿠키 없음/만료/불일치)")
+            }
+    )
+    public SuccessResponse<AccessTokenResponse> refreshAccessToken(
+            @Parameter(hidden = true)
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @CookieValue(value = "refresh_token") String refreshToken
+    );
 }

--- a/src/main/java/com/koa/koalamailman/domain/auth/dto/AccessTokenResponse.java
+++ b/src/main/java/com/koa/koalamailman/domain/auth/dto/AccessTokenResponse.java
@@ -1,0 +1,9 @@
+package com.koa.koalamailman.domain.auth.dto;
+
+public record AccessTokenResponse(
+        String accessToken
+) {
+    public static AccessTokenResponse from(String accessToken) {
+        return new AccessTokenResponse(accessToken);
+    }
+}

--- a/src/main/java/com/koa/koalamailman/domain/auth/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/koa/koalamailman/domain/auth/repository/RefreshTokenRepository.java
@@ -1,0 +1,13 @@
+package com.koa.koalamailman.domain.auth.repository;
+
+import com.koa.koalamailman.domain.auth.repository.entity.RefreshToken;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
+
+    Optional<RefreshToken> findByUserId(Long userId);
+}

--- a/src/main/java/com/koa/koalamailman/domain/auth/repository/entity/RefreshToken.java
+++ b/src/main/java/com/koa/koalamailman/domain/auth/repository/entity/RefreshToken.java
@@ -1,0 +1,46 @@
+package com.koa.koalamailman.domain.auth.repository.entity;
+
+import com.koa.koalamailman.domain.mandalart.repository.entity.BaseEntity;
+import com.koa.koalamailman.domain.mandalart.repository.entity.MandalartEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Table(name = "token")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder(access = AccessLevel.PRIVATE)
+public class RefreshToken extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private Long userId;
+
+    @Column(nullable = false, length = 32)
+    private byte[] tokenHash;
+
+    @Version
+    @Column(nullable = false)
+    private Integer version;
+
+    @Column(nullable = false)
+    private LocalDateTime expiresAt;
+
+    public static RefreshToken create(Long userId, byte[] tokenHash, LocalDateTime expiresAt) {
+        return RefreshToken.builder()
+                .userId(userId)
+                .tokenHash(tokenHash)
+                .expiresAt(expiresAt)
+                .build();
+    }
+
+    public void updateToken(byte[] tokenHash, LocalDateTime expiresAt) {
+        this.tokenHash = tokenHash;
+        this.expiresAt = expiresAt;
+    }
+}

--- a/src/main/java/com/koa/koalamailman/domain/auth/service/AccessTokenService.java
+++ b/src/main/java/com/koa/koalamailman/domain/auth/service/AccessTokenService.java
@@ -1,0 +1,19 @@
+package com.koa.koalamailman.domain.auth.service;
+
+import com.koa.koalamailman.domain.user.repository.User;
+import com.koa.koalamailman.global.token.JwtProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AccessTokenService {
+    private final JwtProvider jwtProvider;
+    @Value("${jwt.access.expiration}")
+    private long accessExpirationTimeMs;
+
+    public String createAccessToken(User user) {
+        return jwtProvider.generateToken(user, accessExpirationTimeMs);
+    }
+}

--- a/src/main/java/com/koa/koalamailman/domain/auth/service/RefreshTokenService.java
+++ b/src/main/java/com/koa/koalamailman/domain/auth/service/RefreshTokenService.java
@@ -1,0 +1,72 @@
+package com.koa.koalamailman.domain.auth.service;
+
+import com.koa.koalamailman.domain.auth.repository.RefreshTokenRepository;
+import com.koa.koalamailman.domain.auth.repository.entity.RefreshToken;
+import com.koa.koalamailman.domain.user.repository.User;
+import com.koa.koalamailman.global.exception.BaseException;
+import com.koa.koalamailman.global.exception.error.AuthErrorCode;
+import com.koa.koalamailman.global.token.JwtProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.security.MessageDigest;
+import java.time.Duration;
+import java.time.LocalDateTime;
+
+import static org.apache.commons.codec.digest.HmacUtils.hmacSha256;
+
+@Service
+@RequiredArgsConstructor
+public class RefreshTokenService {
+    private final JwtProvider jwtProvider;
+    private final RefreshTokenRepository refreshTokenRepository;
+    @Value("${jwt.refresh.secret}")
+    private String secretKey;
+
+    @Value("${jwt.refresh.expiration}")
+    private long refreshTokenExpirationMs;
+
+    @Transactional
+    public String validateAndGenerateAccessToken(User user, String rawRefreshToken) {
+        RefreshToken refreshToken = findByUserId(user.getId());
+
+        byte[] incomingHash = hmacSha256(secretKey, rawRefreshToken);
+
+        if (!MessageDigest.isEqual(refreshToken.getTokenHash(), incomingHash)) {
+            throw new BaseException(AuthErrorCode.UNAUTHORIZED);
+        }
+
+        if (refreshToken.getExpiresAt().isBefore(LocalDateTime.now())) {
+            throw new BaseException(AuthErrorCode.UNAUTHORIZED);
+        }
+
+        return jwtProvider.generateToken(user, refreshTokenExpirationMs);
+    }
+    @Transactional
+    public String createRefreshToken(User user) {
+        String rawToken = jwtProvider.generateToken(user, refreshTokenExpirationMs);
+        byte[] tokenHash = hmacSha256(secretKey, rawToken);
+        LocalDateTime expiresAt = LocalDateTime.now().plus(Duration.ofMillis(refreshTokenExpirationMs));
+
+        RefreshToken refreshToken = refreshTokenRepository.findByUserId(user.getId())
+                .orElse(RefreshToken.create(user.getId(),  tokenHash, expiresAt));
+        refreshToken.updateToken(tokenHash, expiresAt);
+
+        refreshTokenRepository.save(refreshToken);
+
+        return rawToken;
+    }
+
+    @Transactional
+    public void extendRefreshToken(User user, byte[] tokenHash) {
+        RefreshToken refreshToken = findByUserId(user.getId());
+        refreshToken.updateToken(tokenHash, LocalDateTime.now().plus(Duration.ofMillis(refreshTokenExpirationMs)));
+    }
+
+    private RefreshToken findByUserId(Long userId) {
+        return refreshTokenRepository.findByUserId(userId)
+                .orElseThrow(() -> new BaseException(AuthErrorCode.UNAUTHORIZED));
+    }
+}

--- a/src/main/java/com/koa/koalamailman/domain/mandalart/controller/docs/MandalartControllerDocs.java
+++ b/src/main/java/com/koa/koalamailman/domain/mandalart/controller/docs/MandalartControllerDocs.java
@@ -10,13 +10,14 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 
-//@SecurityRequirement(name = "Authorization")
+@SecurityRequirement(name = "Authorization")
 @Tag(name = "만다라트", description = "만다라트 관련 API입니다.")
 public interface MandalartControllerDocs {
     @Operation(summary = "만다라트 생성")

--- a/src/main/java/com/koa/koalamailman/domain/user/controller/docs/UserControllerDocs.java
+++ b/src/main/java/com/koa/koalamailman/domain/user/controller/docs/UserControllerDocs.java
@@ -16,7 +16,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 
 
-//@SecurityRequirement(name = "Authorization")
+@SecurityRequirement(name = "Authorization")
 @Tag(name = "사용자", description = "사용자 관련 API입니다.")
 public interface UserControllerDocs {
     @Operation(summary = "유저 정보 조회")
@@ -38,7 +38,7 @@ public interface UserControllerDocs {
             @ApiResponse(responseCode = "404", description = "유저를 찾을 수 없음",
                     content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
     })
-    SuccessResponse updateUserProfile(
+    SuccessResponse<Void> updateUserProfile(
             @Parameter(hidden = true)
             @AuthenticationPrincipal CustomUserDetails userDetails,
             final UpdateUserProfileRequest request

--- a/src/main/java/com/koa/koalamailman/domain/user/repository/User.java
+++ b/src/main/java/com/koa/koalamailman/domain/user/repository/User.java
@@ -1,10 +1,8 @@
 package com.koa.koalamailman.domain.user.repository;
 
+import com.koa.koalamailman.domain.mandalart.repository.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
-import org.hibernate.annotations.CreationTimestamp;
-
-import java.time.LocalDateTime;
 
 @Entity
 @Table(name = "user", uniqueConstraints = {
@@ -12,7 +10,7 @@ import java.time.LocalDateTime;
 })
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class User {
+public class User extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -39,10 +37,6 @@ public class User {
 
     @Column
     private String job;
-
-    @CreationTimestamp
-    @Column(name = "created_at", updatable = false)
-    private LocalDateTime createdAt;
 
     @Builder
     public User(OAuthProvider oauthProvider, String oauthId, String nickname, String email) {

--- a/src/main/java/com/koa/koalamailman/global/exception/SuccessCode.java
+++ b/src/main/java/com/koa/koalamailman/global/exception/SuccessCode.java
@@ -11,6 +11,7 @@ public enum SuccessCode {
     /**
      * 200 SUCCESS
      */
+    GET_ACCESS_TOKEN(HttpStatus.OK, "유저 access token 조회 성공입니다."),
     GET_USER_INFO_SUCCESS(HttpStatus.OK, "유저 정보 조회 성공입니다."),
     UPDATE_USER_PROFILE_SUCCESS(HttpStatus.OK, "유저 프로필 업데이트 성공입니다."),
 

--- a/src/main/java/com/koa/koalamailman/global/security/filter/TokenAuthenticationFilter.java
+++ b/src/main/java/com/koa/koalamailman/global/security/filter/TokenAuthenticationFilter.java
@@ -12,7 +12,6 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
-import org.springframework.web.util.WebUtils;
 
 import java.io.IOException;
 
@@ -40,10 +39,6 @@ public class TokenAuthenticationFilter extends OncePerRequestFilter {
     }
 
     private String extractTokenFromRequest(HttpServletRequest request) {
-        var cookie = WebUtils.getCookie(request, "access_token");
-        if (cookie != null && StringUtils.hasText(cookie.getValue())) {
-            return cookie.getValue();
-        }
         String bearer = request.getHeader("Authorization");
         if (StringUtils.hasText(bearer) && bearer.startsWith("Bearer ")) {
             return bearer.substring(7);

--- a/src/main/java/com/koa/koalamailman/global/security/oauth/CustomUserDetails.java
+++ b/src/main/java/com/koa/koalamailman/global/security/oauth/CustomUserDetails.java
@@ -24,6 +24,11 @@ public class CustomUserDetails implements UserDetails {
         return user.getEmail();
     }
 
+    public User getUser() {
+        return user;
+    }
+
+
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
         return List.of(new SimpleGrantedAuthority("ROLE_USER"));

--- a/src/main/java/com/koa/koalamailman/global/token/CookieProvider.java
+++ b/src/main/java/com/koa/koalamailman/global/token/CookieProvider.java
@@ -1,0 +1,23 @@
+package com.koa.koalamailman.global.token;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.ResponseCookie;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+
+@Component
+@RequiredArgsConstructor
+public class CookieProvider {
+    @Value("${jwt.refresh.expiration}")
+    private long refreshTokenExpiration;
+    public ResponseCookie setRefreshTokenCookie(String refreshToken) {
+        return ResponseCookie.from("refresh_token", refreshToken)
+                .httpOnly(true)
+                .secure(true)
+                .path("/")
+                .maxAge(Duration.ofMillis(refreshTokenExpiration))
+                .sameSite("STRICT")
+                .build();
+    }
+}

--- a/src/main/java/com/koa/koalamailman/global/token/JwtProvider.java
+++ b/src/main/java/com/koa/koalamailman/global/token/JwtProvider.java
@@ -25,11 +25,9 @@ public class JwtProvider {
 
     private final CustomUserDetailsService userDetailsService;
 
-    @Value("${jwt.secret}")
+    @Value("${jwt.access.secret}")
     private String secretKey;
 
-    @Value("${jwt.expiration}")
-    private long expirationTime;
     private Algorithm algorithm;
 
     @PostConstruct
@@ -37,12 +35,12 @@ public class JwtProvider {
         this.algorithm = Algorithm.HMAC256(secretKey);
     }
 
-    public String generateAccessToken(User user) {
+    public String generateToken(User user, long expirationTimeMs) {
         return JWT.create()
                 .withSubject(user.getId().toString())
                 .withClaim("email", user.getEmail())
                 .withIssuedAt(new Date())
-                .withExpiresAt(new Date(System.currentTimeMillis() + expirationTime))
+                .withExpiresAt(new Date(System.currentTimeMillis() + expirationTimeMs))
                 .sign(algorithm);
     }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -90,8 +90,12 @@ sendgrid:
   api-key: ${SENDGRID_API_KEY}
 
 jwt:
-  secret: ${JWT_SECRET}
-  expiration: ${JWT_EXPIRATION:3600000}
+  access:
+    secret: ${JWT_SECRET}
+    expiration: ${JWT_EXPIRATION:3600000}
+  refresh:
+    secret: ${JWT_SECRET}
+    expiration: ${JWT_REFRESH_EXPIRATION:3600000}
 
 management:
   endpoints:


### PR DESCRIPTION
- Refresh Token 쿠키는 String, DB에는 해시(byte[]) 저장하도록 수정 및 파일들 역할 분리 리팩토링
- Swagger 문서에서 작성